### PR TITLE
fix: allow to build adt-creator on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,24 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.22)
 project(adt-creator VERSION 1.0)
-include (FetchContent)
+include(FetchContent)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-FetchContent_Declare(
+fetchcontent_declare(
   thread_pool
   GIT_REPOSITORY https://github.com/bshoshany/thread-pool.git
-  GIT_TAG        v2.0.0
+  GIT_TAG v3.1.0
 )
-FetchContent_MakeAvailable(thread_pool)
+fetchcontent_makeavailable(thread_pool)
 
-file(GLOB sources
-     "*.h"
-     "*.cpp"
-)
+file(GLOB sources "*.h" "*.cpp")
 
-add_executable(adt-creator ${sources} ${thread_pool_SOURCE_DIR}/thread_pool.hpp)
-target_include_directories(adt-creator PUBLIC
-     "${PROJECT_SOURCE_DIR}"
-     ${thread_pool_SOURCE_DIR}
-)
+add_executable(adt-creator ${sources})
+target_include_directories(adt-creator PUBLIC "${PROJECT_SOURCE_DIR}" ${thread_pool_SOURCE_DIR})
 
 if(UNIX)
-	set(THREADS_PREFER_PTHREAD_FLAG ON)
-	find_package(Threads REQUIRED)
-	target_link_libraries(blpconverter PRIVATE Threads::Threads)
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
+  target_link_libraries(adt-creator PRIVATE Threads::Threads)
 endif()

--- a/adtAdder.cpp
+++ b/adtAdder.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <string>
 #include <filesystem>
-#include "thread_pool.hpp"
+#include "BS_thread_pool.hpp"
 
 void writeAdt(std::string sourceFile, std::string dstDir, std::string dstName, int minAdtX, int minAdtY, int maxAdtX, int maxAdtY)
 {
@@ -56,8 +56,8 @@ void writeAdt(std::string sourceFile, std::string dstDir, std::string dstName, i
 
 	std::cout << "Writing ADT files\n";
 
-	synced_stream sync_out;
-	thread_pool pool;
+	BS::synced_stream sync_out;
+	BS::thread_pool pool;
 	for (int x = minAdtX; x <= maxAdtX; ++x)
 	{
 		for (int y = minAdtY; y <= maxAdtY; ++y)

--- a/mash.cpp
+++ b/mash.cpp
@@ -16,11 +16,16 @@
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
-#include <windows.h> //Used in creating directory
+#ifdef _WIN32
+#include <windows.h>
+#include <direct.h>
+#else
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
+#endif
 
-#include "thread_pool.hpp"
+#include "BS_thread_pool.hpp"
 #include "list.h" //Makes my life so much easier
 #include "zoneGroup.h" //Custom class that contains information about a group of ADTs
 #include "offsetFix.h" //Used in fixing offsets after movement
@@ -38,8 +43,8 @@ int mash(list<ZoneGroup> zoneGroupList, std::string outputName, bool offsetFixEn
     if(offsetFixEnabled){
         std::cout << "Correcting offsets\n";
 
-	    synced_stream sync_out;
-	    thread_pool pool;
+	    BS::synced_stream sync_out;
+	    BS::thread_pool pool;
 
 
         for(int i=0; i < zoneGroupList[0].getSize(); i++) //Fix each file


### PR DESCRIPTION
Fixes included:

- use a current CMake version (3.22 because Ubuntu 22.04 and newer)
- bump Thread Pool dependency to 3.1.0 and upgrade code using it
- fix includes to cover Windows/non-Windows use case